### PR TITLE
fix: use React.PropsWithChildren

### DIFF
--- a/src/ScrollComponents/ScrollView.tsx
+++ b/src/ScrollComponents/ScrollView.tsx
@@ -12,7 +12,9 @@ import { useCollapsibleStyle } from '../useCollapsibleStyle'
 /**
  * Use like a regular ScrollView.
  */
-export const ScrollView: React.FC<Omit<ScrollViewProps, 'onScroll'>> = ({
+export const ScrollView: React.FC<
+  React.PropsWithChildren<Omit<ScrollViewProps, 'onScroll'>>
+> = ({
   contentContainerStyle,
   style,
   onContentSizeChange,


### PR DESCRIPTION
Fix typescript error when using `Segmented.ScrollView` https://github.com/PedroBern/react-native-collapsible-segmented-view/issues/7